### PR TITLE
Remove trace from side bar

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,6 @@ docs_dir = dirname(@__FILE__)
 testcases_dir = joinpath(dirname(dirname(@__FILE__)), "testcases")
 
 plot_bool = true
-const EXAMPLES = Any["examples/cases.md"]
 
 makedocs(
     modules = [HydroPowerModels],
@@ -18,7 +17,7 @@ makedocs(
         "Home"      => "index.md",
         "Manual"    => "getstarted.md",
         "Case data" => "inputfiles.md",
-        "Examples"  => EXAMPLES,
+        "Examples"  => "examples/cases.md",
         "Reference" => "apireference.md"
     ]
 )


### PR DESCRIPTION
This should fix the small - in the sidebar of the documentation.